### PR TITLE
require escalation done before calling the role

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,5 +2,6 @@
 - name: Converge
   hosts: all
   connection: local
+  become: true
   roles:
     - role: "infra_monkey.base_system"

--- a/tasks/install-packages-Debian.yml
+++ b/tasks/install-packages-Debian.yml
@@ -6,7 +6,6 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  become: true
   when: use_debian_backports
 - name: "Ensure unwanted packages are absent"
   apt:
@@ -15,14 +14,12 @@
     autoremove: true
     state: absent
     purge: true
-  become: true
 - name: "Install required packages"
   apt:
     name: "{{ pkglist }}"
     update_cache: true
     autoremove: true
     state: present
-  become: true
 - name: "Install required backport packages"
   apt:
     name: "{{ backport_pkglist }}"
@@ -30,6 +27,5 @@
     update_cache: true
     autoremove: true
     state: present
-  become: true
   when: use_debian_backports and backport_pkglist is defined
 ...

--- a/tasks/install-packages-RedHat.yml
+++ b/tasks/install-packages-RedHat.yml
@@ -3,11 +3,9 @@
   package:
     name: "epel-release"
     state: present
-  become: true
   when: enable_epel is defined and enable_epel
 - name: "Install required packages"
   package:
     name: "{{ pkglist }}"
     state: present
-  become: true
 ...


### PR DESCRIPTION
To keep it simple, all the actions need privilege escalation. So managing the escalation before calling the role greatly simplifies the code.