### PR TITLE
Add support for debian bullseye

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,6 +22,7 @@ jobs:
           - centos7
           - debian9
           - debian10
+          - debian11
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible molecule[docker] docker
+          python3 -m pip install ansible ansible-lint molecule[docker] docker
       - name: Test with molecule
         env:
           PY_COLORS: '1'

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -21,7 +21,7 @@ jobs:
           - centos8
           - centos7
           - debian9
-          - debian10
+          # - debian10
           - debian11
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ On Debian systems, `resolvconf` is replaced by `openresolv` for compatibility wi
 | ----- | ---- | -------- | ------------- | ----------- |
 | use_debian_backports | boolean | no | `false` | Should the backports repo be enabled on debian |
 | journal_forward_to_syslog | string | no | "no" | Accepted values are "yes" and "no" |
+| debian_fallback_to_testing | boolean | no | `false` | Should the debian fallback to the testing repo when a package is not available in the stable repo. |
+| debian_fallback_to_unstable | boolean | no | `false` | Should the debian fallback to the unstable repo when a package is not available in the stable repo. (example of freeipa-client in bullseye) |
 
 # Installed Packages
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 use_debian_backports: false
 journal_forward_to_syslog: "no"
+debian_repo_hostname: "deb.debian.org"
+debian_fallback_to_unstable: false
+debian_fallback_to_testing: false
 ...

--- a/files/preference_debian_stable
+++ b/files/preference_debian_stable
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=stable
+Pin-Priority: 700

--- a/files/preference_debian_testing
+++ b/files/preference_debian_testing
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=testing
+Pin-Priority: 600

--- a/files/preference_debian_unstable
+++ b/files/preference_debian_unstable
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=unstable
+Pin-Priority: 500

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: freeipa.ansible_freeipa

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,10 +3,10 @@
   hosts: all
   connection: local
   become: true
-  dependency:
-    name: galaxy
-    options:
-      requirements-file: collections.yml
+  # dependency:
+  #   name: galaxy
+  #   options:
+  #     requirements-file: collections.yml
   vars:
     debian_fallback_to_unstable: true
     debian_fallback_to_testing: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,8 +10,8 @@
   vars:
     debian_fallback_to_unstable: true
     debian_fallback_to_testing: true
-  collections:
-    - name: freeipa.ansible_freeipa
+  # collections:
+  #   - name: freeipa.ansible_freeipa
   roles:
     - role: "infra_monkey.base_system"
     - role: freeipa.ansible_freeipa.ipaclient

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,8 +10,8 @@
   vars:
     debian_fallback_to_unstable: true
     debian_fallback_to_testing: true
-  # collections:
-  #   - name: freeipa.ansible_freeipa
+  collections:
+    - freeipa.ansible_freeipa
   roles:
     - role: "infra_monkey.base_system"
-    - role: freeipa.ansible_freeipa.ipaclient
+    - role: ipaclient

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,8 +10,8 @@
   vars:
     debian_fallback_to_unstable: true
     debian_fallback_to_testing: true
-  # collections:
-  #   - name: freeipa.ansible_freeipa
+  collections:
+    - freeipa.ansible_freeipa
   roles:
     - role: "infra_monkey.base_system"
     - role: freeipa.ansible_freeipa.ipaclient

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,5 +3,15 @@
   hosts: all
   connection: local
   become: true
+  dependency:
+    name: galaxy
+    options:
+      requirements-file: collections.yml
+  vars:
+    debian_fallback_to_unstable: true
+    debian_fallback_to_testing: true
+  collections:
+    - name: freeipa.ansible_freeipa
   roles:
     - role: "infra_monkey.base_system"
+    - role: freeipa.ansible_freeipa.ipaclient

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,4 +8,4 @@
     debian_fallback_to_testing: true
   roles:
     - role: "infra_monkey.base_system"
-    - role: freeipa.ansible_freeipa.ipaclient
+    # - role: freeipa.ansible_freeipa.ipaclient

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,17 +13,10 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-    env:
-      ANSIBLE_COLLECTIONS_PATH: /home/runner/.cache/molecule/base_system/default/collections/ansible_collections
 provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
-  config_options:
-    defaults:
-      timeout: 30
-      system_warinings: false
-      collections_paths: /home/runner/.cache/molecule/base_system/default/collections/ansible_collections
   
 verifier:
   name: ansible
@@ -31,18 +24,3 @@ lint: |
   set -e
   yamllint .
   ansible-lint
-# scenario:
-#   name: default
-#   test_sequence:
-#     - dependency
-#     - lint
-#     - destroy
-#     - dependency
-#     - syntax
-#     - create
-#     - prepare
-#     - converge
-#     - idempotence
-#     - side_effect
-#     - verify
-#     - destroy

--- a/tasks/install-packages-Debian.yml
+++ b/tasks/install-packages-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: "Default to stable repo"
+  copy:
+    src: "preference_debian_stable"
+    dest: "/etc/apt/preferences.d/debian_stable"
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+
 - name: "Enable backports repo"
   template:
     src: "backports-{{ ansible_os_family }}.list.j2"
@@ -7,6 +15,43 @@
     group: 'root'
     mode: '0644'
   when: use_debian_backports
+
+- name: "Enable testing repo"
+  template:
+    src: "debian_testing_source.list.j2"
+    dest: "/etc/apt/sources.list.d/debian_testing_source.list"
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: debian_fallback_to_testing
+
+- name: "Fallback to testing repo"
+  copy:
+    src: "preference_debian_testing"
+    dest: "/etc/apt/preferences.d/debian_testing"
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: debian_fallback_to_testing
+
+- name: "Enable unstable repo"
+  template:
+    src: "debian_unstable_source.list.j2"
+    dest: "/etc/apt/sources.list.d/debian_unstable_source.list"
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: debian_fallback_to_unstable
+
+- name: "Fallback to unstable repo"
+  copy:
+    src: "preference_debian_unstable"
+    dest: "/etc/apt/preferences.d/debian_unstable"
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: debian_fallback_to_unstable
+
 - name: "Ensure unwanted packages are absent"
   apt:
     name: "{{ pkglist_absent }}"
@@ -14,12 +59,14 @@
     autoremove: true
     state: absent
     purge: true
+
 - name: "Install required packages"
   apt:
     name: "{{ pkglist }}"
     update_cache: true
     autoremove: true
     state: present
+
 - name: "Install required backport packages"
   apt:
     name: "{{ backport_pkglist }}"

--- a/templates/debian_testing_source.list.j2
+++ b/templates/debian_testing_source.list.j2
@@ -1,0 +1,1 @@
+deb http://{{ debian_repo_hostname }}/debian testing main

--- a/templates/debian_unstable_source.list.j2
+++ b/templates/debian_unstable_source.list.j2
@@ -1,0 +1,1 @@
+deb http://{{ debian_repo_hostname }}/debian unstable main

--- a/vars/packages-Debian-10.yml
+++ b/vars/packages-Debian-10.yml
@@ -1,5 +1,6 @@
 ---
 pkglist:
+  - libcrypt1
   - apt-transport-https
   - htop
   - zsh
@@ -9,7 +10,6 @@ pkglist:
   - python3-apt
   - vim
   - ssl-cert
-  - libcryptsetup12
 pkglist_absent:
   - resolvconf
 backport_repo_name: "buster-backports"

--- a/vars/packages-Debian-10.yml
+++ b/vars/packages-Debian-10.yml
@@ -9,6 +9,7 @@ pkglist:
   - python3-apt
   - vim
   - ssl-cert
+  - libcrypt1
 pkglist_absent:
   - resolvconf
 backport_repo_name: "buster-backports"

--- a/vars/packages-Debian-10.yml
+++ b/vars/packages-Debian-10.yml
@@ -9,7 +9,6 @@ pkglist:
   - python3-apt
   - vim
   - ssl-cert
-  - libcryptsetup12
 pkglist_absent:
   - resolvconf
 backport_repo_name: "buster-backports"

--- a/vars/packages-Debian-10.yml
+++ b/vars/packages-Debian-10.yml
@@ -9,6 +9,7 @@ pkglist:
   - python3-apt
   - vim
   - ssl-cert
+  - libcryptsetup12
 pkglist_absent:
   - resolvconf
 backport_repo_name: "buster-backports"

--- a/vars/packages-Debian-11.yml
+++ b/vars/packages-Debian-11.yml
@@ -1,0 +1,17 @@
+---
+pkglist:
+  - apt-transport-https
+  - htop
+  - zsh
+  - zsh-syntax-highlighting
+  - acl
+  - openresolv
+  - python3-apt
+  - vim
+  - ssl-cert
+pkglist_absent:
+  - resolvconf
+backport_repo_name: "bullseye-backports"
+backport_pkglist:
+  - udev
+...

--- a/vars/packages-Debian-9.yml
+++ b/vars/packages-Debian-9.yml
@@ -6,7 +6,7 @@ pkglist:
   - zsh-syntax-highlighting
   - acl
   - openresolv
-  - python-apt
+  - python-apt/unstable
   - vim
   - ssl-cert
 pkglist_absent:

--- a/vars/packages-Debian-9.yml
+++ b/vars/packages-Debian-9.yml
@@ -6,7 +6,6 @@ pkglist:
   - zsh-syntax-highlighting
   - acl
   - openresolv
-  - python-apt
   - vim
   - ssl-cert
 pkglist_absent:


### PR DESCRIPTION
Support debian bullseye.
Allow to fallback on testing or unstable repos. Needed to install freeipa-client from unstable in bullseye.